### PR TITLE
Invalidate intrinsic content size when updating ShiftMaskableLabel text

### DIFF
--- a/Shift/Classes/ShiftUI.swift
+++ b/Shift/Classes/ShiftUI.swift
@@ -127,6 +127,7 @@ open class ShiftMaskableLabel: ShiftView {
     public func setText(_ text: String) {
         textLabel.text = text
         textLabel.sizeToFit()
+        invalidateIntrinsicContentSize()
     }
     
 }


### PR DESCRIPTION
I'm using `ShiftMaskableLabel` inside a cell and when it gets reused sometimes the text would be clipped and/or with the wrong position.

This seems to fix the issue.